### PR TITLE
Make zenith_services field optional in PlatformSpec

### DIFF
--- a/azimuth_identity/models/v1alpha1/platform.py
+++ b/azimuth_identity/models/v1alpha1/platform.py
@@ -27,7 +27,7 @@ class PlatformSpec(schema.BaseModel):
         ...,
         description = "The name of the realm that the platform belongs to."
     )
-    zenith_services: schema.Dict[str, ZenithServiceSpec] = Field(
+    zenith_services: t.Optional[schema.Dict[str, ZenithServiceSpec]] = Field(
         default_factory = dict,
         description = (
             "Map of name to subdomain and FQDN for Zenith services belonging to the platform."


### PR DESCRIPTION
When creating a k8s cluster and then updating it to remove the dashboard and monitoring addons, we see the following message in the Azimuth CAPI operator logs
```
easykube.kubernetes.client.errors.ApiError: Platform.identity.azimuth.stackhpc.com "kube-test-cluster" is invalid: spec.zenithServices: Invalid value: "null": spec.zenithServices in body must be of type object: "null"
```
This error also makes all subsequent updates to the cluster fail so only option is to delete then recreate cluster. Not sure if this is the right fix, need to find time to test properly.