### PR TITLE
Fix platform 'allowed groups' race condition on operator upgrade

### DIFF
--- a/azimuth_identity/operator.py
+++ b/azimuth_identity/operator.py
@@ -80,6 +80,14 @@ async def on_cleanup(**kwargs):
     await keycloak.client.close()
 
 
+def is_cloud_tenancy_realm(instance: api.Realm) -> bool:
+    """
+    Returns true if the provided realm is for a cloud
+    tenancy and false if the realm is for OIDC mode.
+    """
+    return instance.spec.tenancy_id is not None
+
+
 def format_instance(instance):
     """
     Formats an instance for logging.
@@ -165,7 +173,7 @@ async def reconcile_realm(instance: api.Realm, **kwargs):
     await keycloak.realm.ensure_groups_scope(instance, realm_name)
     # If required, configure the realm as a tenancy realm
     # If not, just leave it as a vanilla realm
-    if instance.spec.tenancy_id:
+    if is_cloud_tenancy_realm(instance):
         # Ensure that the Dex instance for the realm exists
         dex_client = await dex.ensure_realm_instance(ekclient, instance, realm_name)
         # Make sure that the profile requirements for the realm are set up correctly
@@ -185,7 +193,7 @@ async def reconcile_realm(instance: api.Realm, **kwargs):
     # Keycloak group names are prefixed with a slash
     instance.status.platform_users_group = (
         f"/{settings.keycloak.platform_users_group_name}"
-        if instance.spec.tenancy_id
+        if is_cloud_tenancy_realm(instance)
         else None
     )
     LOGGER.info(
@@ -392,16 +400,14 @@ async def reconcile_platform(instance: api.Platform, param, **kwargs):
         )
         # Calculate the allowed groups
         allowed_groups = [
-            # Add the platform users group if the realm has one
-            realm.status.get(
-                "platform_users_group",
-                f"/{settings.keycloak.platform_users_group_name}",
-            ),
             # Allow the parent group for the platform
             group["path"],
             # Allow users to be added to a subgroup for the specific service
             subgroup["path"],
         ]
+        # Add the platform users group if the realm has one
+        if is_cloud_tenancy_realm(realm):
+            allowed_groups.insert(0, f"/{settings.keycloak.platform_users_group_name}")
         await ekclient.apply_object(
             {
                 "apiVersion": "v1",


### PR DESCRIPTION
Commit 80d0c8e8ee8b1a6dd6c06098be8ba06e8f3fe6ac introduced a subtle bug where, upon upgrading the operator to version 0.9.0 using standard Azimuth tooling, the `/platform-users` group is inadvertently dropped from the allowed groups list for all platforms deployed prior to the upgrade. This causes HTTP 403 errors in the browser when a user attempts to access any Zenith service for the previously deployed platform.

The root cause of this bug is as follows:

During an Azimuth upgrade, when the new identity operator chart gets installed it restarts the identity operator container and triggers the ‘on resume’ handler for both the Realm and Platform CRDs. This means that both realms and platforms get reconciled at the same time so the Platform resources get reconciled before the operator has added the status.platform_users_group field to the Realm and this causes `/platform-users` to be removed from the allowed groups.

The fix proposed here is to decouple the Platform reconciliation loop from the Realm's status field.